### PR TITLE
fix(swiper): improve component implementation and dependencies

### DIFF
--- a/src/components/Swiper.astro
+++ b/src/components/Swiper.astro
@@ -3,17 +3,15 @@
 // MIT License
 
 import 'swiper/css/bundle'
-
 import type { AstroSwiperType } from '../index'
 
 type Props = AstroSwiperType
 
-
 const {
   options={},
-  class: className = '',
-  uniqueClass = 'astro-swiper-' + Math.random().toString(36).slice(2, 11),
-  linkToThumbUniqueClass = '',
+  uniqueClass = `astro-swiper-${crypto.randomUUID()}`,
+  class: className = null,
+  linkToThumbUniqueClass = null,
   ...props
 } = Astro.props;
 
@@ -32,7 +30,7 @@ const {
 
 
 <script>
-  import Swiper from 'swiper/bundle'
+  import Swiper from 'swiper'
   import type { SwiperOptions } from 'swiper/types';
 
   /** contains the swiper json object once created, for each uniqueClass */

--- a/src/components/Swiper.astro
+++ b/src/components/Swiper.astro
@@ -30,7 +30,7 @@ const {
 
 
 <script>
-  import Swiper from 'swiper'
+  import Swiper from 'swiper/bundle'
   import type { SwiperOptions } from 'swiper/types';
 
   /** contains the swiper json object once created, for each uniqueClass */

--- a/src/components/Swiper.astro
+++ b/src/components/Swiper.astro
@@ -9,7 +9,7 @@ type Props = AstroSwiperType
 
 const {
   options={},
-  uniqueClass = `astro-swiper-${crypto.randomUUID()}`,
+  uniqueClass = `astro-swiper-${Math.random().toString(36).slice(2, 11)}`,
   class: className = null,
   linkToThumbUniqueClass = null,
   ...props

--- a/src/components/SwiperSlide.astro
+++ b/src/components/SwiperSlide.astro
@@ -3,7 +3,6 @@
 // MIT License
 
 import 'swiper/css/bundle'
-
 import type { HTMLAttributes } from 'astro/types'
 
 interface Props extends HTMLAttributes<"div"> {
@@ -20,7 +19,7 @@ const {
 ---
 
 <div
-  class:list={[(addDefaultClass ? 'swiper-slide' : ''), className]}
+  class:list={[(addDefaultClass ? 'swiper-slide' : null), className]}
   {...props}>
     <slot/>
 </div>


### PR DESCRIPTION
Fix basic noticed issues within astro files.

- change default `className` and `linkToThumbUniqueClass` from empty string to null for better null coalescing
- Update SwiperSlide to use null instead of empty string in conditional class binding