### PR TITLE
fix: cleanup components empty string classes rendering in output

### DIFF
--- a/src/components/Swiper.astro
+++ b/src/components/Swiper.astro
@@ -25,13 +25,13 @@ const {
       data-options={JSON.stringify(options)}
       data-linktothumbuniqueclass={linkToThumbUniqueClass}
       data-uniqueclass={uniqueClass}
-      class:list={[addDefaultClass ? 'swiper' : '', uniqueClass, className]}
+      class:list={[addDefaultClass ? 'swiper' : null, uniqueClass, className]}
       {...props}
     >
       <slot />
     </astro-swiper>
   ) : (
-    <div class:list={[addDefaultClass ? 'swiper' : '', uniqueClass, className]} {...props} >
+    <div class:list={[addDefaultClass ? 'swiper' : null, uniqueClass, className]} {...props} >
       <astro-swiper
         data-options={JSON.stringify(options)}
         data-linktothumbuniqueclass={linkToThumbUniqueClass}
@@ -69,7 +69,8 @@ const {
 
       // Read the message from the data attribute.
       const options = JSON.parse(this.dataset.options || '{}');
-      const uniqueClass = this.dataset.uniqueclass || ''; // to have more than 1 swiper in a single page
+      // to have more than 1 swiper in a single page
+      const uniqueClass = this.dataset.uniqueclass || ''; 
       const linkToThumbUniqueClass = this.dataset.linktothumbuniqueclass || '';
 
       if (linkToThumbUniqueClass === '') {

--- a/src/components/SwiperButtonNext.astro
+++ b/src/components/SwiperButtonNext.astro
@@ -11,9 +11,9 @@ interface Props extends HTMLAttributes<'div'> {
   addDefaultClass?: boolean;
 }
 
-const { class: className = '', addDefaultClass = true, ...props } = Astro.props;
+const { class: className = null, addDefaultClass = true, ...props } = Astro.props;
 ---
 
-<div class:list={[addDefaultClass ? 'swiper-button-next' : '', className]} {...props}>
+<div class:list={[addDefaultClass ? 'swiper-button-next' : null, className]} {...props}>
   <slot />
 </div>

--- a/src/components/SwiperButtonPrev.astro
+++ b/src/components/SwiperButtonPrev.astro
@@ -11,9 +11,9 @@ interface Props extends HTMLAttributes<'div'> {
   addDefaultClass?: boolean;
 }
 
-const { class: className = '', addDefaultClass = true, ...props } = Astro.props;
+const { class: className = null, addDefaultClass = true, ...props } = Astro.props;
 ---
 
-<div class:list={[addDefaultClass ? 'swiper-button-prev' : '', className]} {...props}>
+<div class:list={[addDefaultClass ? 'swiper-button-prev' : null, className]} {...props}>
   <slot />
 </div>

--- a/src/components/SwiperPagination.astro
+++ b/src/components/SwiperPagination.astro
@@ -11,9 +11,9 @@ interface Props extends HTMLAttributes<'div'> {
   addDefaultClass?: boolean;
 }
 
-const { class: className = '', addDefaultClass = true, ...props } = Astro.props;
+const { class: className = null, addDefaultClass = true, ...props } = Astro.props;
 ---
 
-<div class:list={[addDefaultClass ? 'swiper-pagination' : '', className]} {...props}>
+<div class:list={[addDefaultClass ? 'swiper-pagination' : null, className]} {...props}>
   <slot />
 </div>

--- a/src/components/SwiperScrollbar.astro
+++ b/src/components/SwiperScrollbar.astro
@@ -11,9 +11,9 @@ interface Props extends HTMLAttributes<'div'> {
   addDefaultClass?: boolean;
 }
 
-const { class: className = '', addDefaultClass = true, ...props } = Astro.props;
+const { class: className = null, addDefaultClass = true, ...props } = Astro.props;
 ---
 
-<div class:list={[addDefaultClass ? 'swiper-scrollbar' : '', className]} {...props}>
+<div class:list={[addDefaultClass ? 'swiper-scrollbar' : null, className]} {...props}>
   <slot />
 </div>

--- a/src/components/SwiperSlide.astro
+++ b/src/components/SwiperSlide.astro
@@ -10,7 +10,7 @@ interface Props extends HTMLAttributes<'div'> {
   addDefaultClass?: boolean;
 }
 
-const { class: className = '', addDefaultClass = true, ...props } = Astro.props;
+const { class: className = null, addDefaultClass = true, ...props } = Astro.props;
 ---
 
 <div class:list={[addDefaultClass ? 'swiper-slide' : null, className]} {...props}>

--- a/src/components/SwiperWrapper.astro
+++ b/src/components/SwiperWrapper.astro
@@ -11,9 +11,9 @@ interface Props extends HTMLAttributes<'div'> {
   addDefaultClass?: boolean;
 }
 
-const { class: className = '', addDefaultClass = true, ...props } = Astro.props;
+const { class: className = null, addDefaultClass = true, ...props } = Astro.props;
 ---
 
-<div class:list={[addDefaultClass ? 'swiper-wrapper' : '', className]} {...props}>
+<div class:list={[addDefaultClass ? 'swiper-wrapper' : null, className]} {...props}>
   <slot />
 </div>


### PR DESCRIPTION
- Replace empty string '' with `null` in `class:list` conditionals for cleaner output, it prevents unnecessary empty strings in rendered class attributes